### PR TITLE
lend_bot: Add new script to use REST api only

### DIFF
--- a/alec/api/v1_rest.py
+++ b/alec/api/v1_rest.py
@@ -71,6 +71,7 @@ class PublicApi(object):
 
             # decimal
             elif 'amount' in k or '_fees' in k or k in [
+                    'available',
                     'balance',
                     'fee',
             ]:

--- a/alec/api/v2_rest.py
+++ b/alec/api/v2_rest.py
@@ -212,6 +212,12 @@ class PublicApi(object):
             raise BitfinexClientError('%s %s' % (resp.status_code, resp.text))
         return resp.json()
 
+    def trades(self, symbol):
+        trades = self.public_req('v2/trades/%s/hist' % symbol)
+        for i, trade in enumerate(trades):
+            trades[i] = Trade(trade)
+        return trades
+
     def candles(self,
                 time_frame,
                 symbol,
@@ -402,6 +408,7 @@ def example():
         print()
 
     print('=' * 10, 'public', '=' * 10)
+    output('trades', bfx.trades('fUSD'))
     output('candle(last)', bfx.candles('1m', 'tETHUSD', 'last'))
     output('candle(hist)', bfx.candles('1m', 'tETHUSD', 'hist', limit=3))
 

--- a/alec/scripts/lend_bot.py
+++ b/alec/scripts/lend_bot.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+import argparse
+import logging
+import time
+
+from slacker import Slacker
+
+from alec import config
+from alec.api import v1_rest, v2_rest
+
+slack = Slacker(config.SLACK_TOKEN) if config.SLACK_ENABLE else None
+logger = logging.getLogger(__name__)
+
+
+def log(text):
+    print(time.strftime("%H:%M:%S", time.localtime()) + ' ' + text)
+    if slack:
+        slack.chat.post_message(config.SLACK_CHANNEL, text)
+
+
+class LendBot(object):
+    NORMAL_INTERVAL = 60
+
+    def __init__(self, currency):
+        self._v1_client = v1_rest.FullApi()
+        self._v2_client = v2_rest.PublicApi()
+        self._currency = currency
+        self._wallet = []
+        self._credits = []
+        self._offers = []
+        self._trades = []
+
+    def run(self):
+        while True:
+            self.get_account_info()
+            self.get_public_trades()
+            sleep_time = self.lend_strategy()
+            time.sleep(sleep_time)
+
+    def get_account_info(self):
+        for wallet in self._v1_client.balances():
+            if wallet['currency'].upper() == self._currency and (
+                    wallet['type'] == 'deposit'):
+                self._wallet = wallet
+                break
+        self._credits = self._v1_client.credits()
+        self._offers = self._v1_client.offers()
+
+    def get_public_trades(self):
+        self._trades = self._v2_client.trades('f' + self._currency)
+
+    def lend_strategy(self):
+        logger.debug('wallet: %s', self._wallet)
+        logger.debug('credit: %s', self._credits)
+        logger.debug('offer: %s', self._offers)
+        logger.debug('trades: %s', self._trades)
+        # Re-write the strategy by yourself
+        available = self._wallet['available']
+        log('Availble: %f' % available)
+        if available >= 50:
+            # rate 0 means FRR
+            self.new_offer(self._currency, available, 0, 2)
+        return self.NORMAL_INTERVAL
+
+    def new_offer(self, currency, amount, rate, period):
+        """Create an new offer
+        :param rate: Rate in percentage per day
+        """
+        self._v1_client.new_offer(currency, amount, rate, period)
+        log('Create an new %s offer with amount: %f, rate: %f, period: %d' % (
+            currency, amount, rate, period))
+
+    def cancel_offer(self, offer_id):
+        """Cancel an offer"""
+        self._v1_client.cancel_offer(offer_id)
+        log('Cancel an offer with id: %d' % offer_id)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true')
+    opts = parser.parse_args()
+
+    if opts.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig()
+
+    print('=' * 30)
+    log('LendBot started')
+    monitor = LendBot('USD')
+    monitor.run()
+
+if __name__ == '__main__':
+    main()

--- a/bin/lend_bot
+++ b/bin/lend_bot
@@ -1,0 +1,1 @@
+../alec/scripts/lend_bot.py


### PR DESCRIPTION
Since we don't need realtime trade, we don't have to use btfxwss.
REST api is enough for lend bot.