### PR TITLE
catch timeout exception

### DIFF
--- a/alec/api/bitfinex_v1_rest.py
+++ b/alec/api/bitfinex_v1_rest.py
@@ -50,9 +50,14 @@ class PublicApi(object):
         logger.debug('public_req %s %s', path, params)
 
         for i in range(MAX_RETRY):
-            resp = requests.get(url, params, verify=True,
-                                timeout=REQUEST_TIMEOUT)
-            if 500 <= resp.status_code <= 599:
+            timeout = False
+            try:
+                resp = requests.get(url, params, verify=True,
+                                    timeout=REQUEST_TIMEOUT)
+            except requests.exceptions.Timeout:
+                timeout = True
+
+            if timeout or 500 <= resp.status_code <= 599:
                 logger.warning('server error, sleep a while')
                 time.sleep(2**i)
                 continue
@@ -163,7 +168,8 @@ class AuthedReadonlyApi(PublicApi):
             try:
                 resp = requests.post(url, headers=headers, verify=True,
                                      timeout=REQUEST_TIMEOUT)
-            except requests.exceptions.ConnectionError:
+            except (requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout):
                 if allow_retry:
                     logger.warning('connection error, sleep a while')
                     time.sleep(2**i)


### PR DESCRIPTION
In #24, we adds timeout for requests. However, when timeout, exception
is raised and the bot will crash, which is equally bad. This change
catches the exception and retry so bot can still running.