### PR TITLE
bitfinex_v1_rest: Fix typo in new_limit_order

### DIFF
--- a/alec/api/bitfinex_v1_rest.py
+++ b/alec/api/bitfinex_v1_rest.py
@@ -369,7 +369,7 @@ class FullApi(AuthedReadonlyApi):
         }
         # Do not retry because when connection error happens, the order might
         # already be created at server side.
-        return self._normalize(self.auth_req('v1/order/new', body), allow_retry=False)
+        return self._normalize(self.auth_req('v1/order/new', body, allow_retry=False))
 
     def transfer_wallet(self, currency, amount, wallet_from, wallet_to):
         """Transfer available balances between wallets.


### PR DESCRIPTION
Fix the typo in

3f8f2d  api: bitfinex_v1_rest - Do not retry to create order