### PR TITLE
bug fix: catch any exception from Slacker

### DIFF
--- a/alec/scripts/parse_hbot_log.py
+++ b/alec/scripts/parse_hbot_log.py
@@ -5,6 +5,7 @@
 import argparse
 import datetime
 import decimal
+import logging
 import re
 import time
 
@@ -37,8 +38,8 @@ def log(text, emoji=None):
             if emoji:
                 message = emoji + ' ' + text
             SLACK.chat.post_message(config.SLACK_CHANNEL, message)
-    except slacker.Error:
-        print("Slack api erorr")
+    except Exception:
+        logging.exception('Failed to post message to Slacker')
 
 
 def check_state(date=None):

--- a/alec/scripts/trade_hbot.py
+++ b/alec/scripts/trade_hbot.py
@@ -66,10 +66,8 @@ def log(level, text, emoji=None):
             if emoji:
                 message = emoji + ' ' + text
             SLACK.chat.post_message(config.SLACK_CHANNEL, message)
-    except slacker.Error:
-        print('Slack api erorr')
-    except requests.exceptions.HTTPError:
-        print('Slack time out')
+    except Exception:
+        logging.exception('Failed to post message to Slacker')
 
 
 class WebSocketApi(object):


### PR DESCRIPTION
Sometimes slacker might fail with exceptions other than slacker.Error.
For example, it once threw a JSON exception...  Just catch any exception
so it won't break main logic.